### PR TITLE
Update SLIM Registry URI to Point to Main Branch

### DIFF
--- a/src/jpl/slim/cli.py
+++ b/src/jpl/slim/cli.py
@@ -15,7 +15,7 @@ from rich.table import Table
 from . import VERSION
 
 # Constants
-SLIM_REGISTRY_URI = "https://raw.githubusercontent.com/NASA-AMMOS/slim/yunks128-patch-1/static/data/slim-registry.json"
+SLIM_REGISTRY_URI = "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/data/slim-registry.json"
 SUPPORTED_MODELS = {
     "openai": ["gpt-3.5-turbo", "gpt-4o"],
     "ollama": ["llama3.1", "mistral", "codellama"],


### PR DESCRIPTION
## Purpose
- This PR updates the URI for the SLIM registry to ensure it points to the main branch, enabling consistent and up-to-date access to the registry data.

## Proposed Changes
- **[CHANGE]** Updated the `SLIM_REGISTRY_URI` constant to use the main branch URL (`https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/data/slim-registry.json`) instead of a patch branch URL (`https://raw.githubusercontent.com/NASA-AMMOS/slim/yunks128-patch-1/static/data/slim-registry.json`).

## Issues
- None explicitly linked. This update ensures stability and alignment with the main branch repository.

## Testing
- Verified the functionality of the updated URI by:
  - Testing the application with the updated `SLIM_REGISTRY_URI` to confirm the registry data is fetched successfully.
