### PR TITLE
Automate PyPI Publishing via GitHub Actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Extract version from tag and update VERSION.txt
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "$TAG_VERSION" > src/jplslim/VERSION.txt
-          echo "Updated src/jplslim/VERSION.txt to $TAG_VERSION"
+          echo "$TAG_VERSION" > src/jpl/slim/VERSION.txt
+          echo "Updated src/jpl/slim/VERSION.txt to $TAG_VERSION"
 
       - name: Install build tools
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,40 @@
+name: Publish Python 🐍 Package to PyPI
+
+on:
+  push:
+    tags:
+      - 'v0.0.8'  # e.g., v1.2.3
+
+jobs:
+  publish:
+    name: Build and Publish to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Extract version from tag and update VERSION.txt
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "$TAG_VERSION" > src/jplslim/VERSION.txt
+          echo "Updated src/jplslim/VERSION.txt to $TAG_VERSION"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build wheel twine
+
+      - name: Build package
+        run: python -m build .
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -407,14 +407,31 @@ pytest -v -s
 
 ### Publishing a New Version
 
-To publish a new version of SLIM CLI to the Python Package Index, typically you'll update the `VERSION.txt` file; then do:
-```bash
-pip install build wheel twine
-python3 -m build .
-twine upload dist/*
-```
+To publish a new version of SLIM CLI to the Python Package Index, follow these steps:
 
-(Note: this can and should eventually be automated with GitHub Actions.)
+1. Create a Git tag for the new version:
+   ```bash
+   # Create the tag (use the appropriate version number)
+   git tag v0.1.0
+   
+   # Push the tag to the repository
+   git push origin v0.1.0
+   ```
+
+2. The GitHub Actions workflow will automatically:
+   - Extract the version from the tag
+   - Update the version file
+   - Build the package
+   - Publish it to PyPI
+
+If you need to remove a tag (e.g., if there was an issue):
+```bash
+# Remove the tag locally
+git tag -d v0.1.0
+
+# Remove the tag from the remote repository
+git push --delete origin v0.1.0
+```
 
 ## License
 


### PR DESCRIPTION
## Purpose  
- Automate the build and publishing process of the SLIM CLI Python package to PyPI upon pushing a version tag.

## Proposed Changes  
- [ADD] New GitHub Actions workflow `.github/workflows/publish-to-pypi.yml` that:
  - Extracts version from the pushed tag
  - Updates `src/jpl/slim/VERSION.txt`
  - Builds the package using `build`
  - Publishes it to PyPI using `twine`
- [CHANGE] Updated `README.md` with detailed instructions on how to tag a new release and trigger publishing workflow

## Issues  
- #22 

## Testing  
- Verified publishing workflow using tag `v0.0.8`
- Confirmed `VERSION.txt` update and successful build step  
- Verified PyPI publication trigger using stored `PYPI_API_TOKEN` secret
