### PR TITLE
Suggestions for issue-11 PR fixes

### DIFF
--- a/src/jpl/slim/docgen/generator.py
+++ b/src/jpl/slim/docgen/generator.py
@@ -17,7 +17,7 @@ from jpl.slim.docgen.enhancer.ai_enhancer import AIEnhancer
 from jpl.slim.docgen.template.template_manager import TemplateManager
 from jpl.slim.docgen.template.config_updater import ConfigUpdater
 from jpl.slim.docgen.site_reviser import SiteReviser
-from jpl.slim.docgen.utils.helpers import load_config, escape_mdx_special_characters, clean_api_doc
+from jpl.slim.docgen.utils.helpers import load_config, escape_mdx_special_characters, clean_api_doc, escape_yaml_value
 
 
 class SlimDocGenerator:
@@ -170,7 +170,7 @@ class SlimDocGenerator:
                         # Add frontmatter
                         f.write("---\n")
                         f.write(f"id: {section_id}\n")
-                        f.write(f"title: {section_title}\n")
+                        f.write(f"title: {escape_yaml_value(section_title)}\n")
                         f.write("---\n\n")
                         f.write(content)
                     self.logger.info(f"Generated {section_id} content")
@@ -284,7 +284,7 @@ class SlimDocGenerator:
                 if frontmatter:
                     output_content = "---\n"
                     for key, value in frontmatter.items():
-                        output_content += f"{key}: {value}\n"
+                        output_content += f"{key}: {escape_yaml_value(str(value))}\n"
                     output_content += "---\n\n" + enhanced_content
                 else:
                     output_content = enhanced_content
@@ -348,7 +348,7 @@ class SlimDocGenerator:
             f.write("---\n")
             f.write("slug: /\n")
             f.write("id: index\n")
-            f.write(f"title: {project_name} Documentation\n")
+            f.write(f"title: {escape_yaml_value(f'{project_name} Documentation')}\n")
             f.write("---\n\n")
             f.write(index_content)
         

--- a/src/jpl/slim/docgen/utils/helpers.py
+++ b/src/jpl/slim/docgen/utils/helpers.py
@@ -239,6 +239,34 @@ def _is_common_html_tag(tag_name: str) -> bool:
     return tag_name.lower() in common_tags or (tag_name[0].isupper() if tag_name else False)
 
 
+def escape_yaml_value(value: str) -> str:
+    """
+    Escape a value for safe inclusion in YAML front matter.
+    
+    This function ensures that string values containing special characters
+    (like colons, quotes, etc.) are properly quoted in YAML.
+    
+    Args:
+        value: String value to escape for YAML
+        
+    Returns:
+        Properly escaped/quoted value for YAML
+    """
+    if not value:
+        return '""'
+    
+    # Check if the value needs quoting
+    # Values with colons, quotes, or other YAML special characters need to be quoted
+    needs_quoting = any(char in value for char in [':', '"', "'", '[', ']', '{', '}', '|', '>', '@', '`'])
+    
+    if needs_quoting:
+        # Use double quotes and escape any internal double quotes
+        escaped_value = value.replace('"', '\\"')
+        return f'"{escaped_value}"'
+    
+    return value
+
+
 def clean_api_doc(api_doc_path: str) -> None:
     """
     Clean up the API documentation file to fix common MDX parsing issues.

--- a/tests/jpl/slim/test_litellm_integration.py
+++ b/tests/jpl/slim/test_litellm_integration.py
@@ -12,11 +12,12 @@ from jpl.slim.commands.common import check_model_availability, get_recommended_m
 class TestLiteLLMIntegration:
     """Test LiteLLM integration functionality."""
     
-    @patch('jpl.slim.utils.ai_utils.completion')
+    @patch('litellm.completion')
     def test_generate_with_litellm_success(self, mock_completion):
         """Test successful generation with LiteLLM."""
         # Mock response
         mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Generated content"
         mock_completion.return_value = mock_response
         
@@ -25,11 +26,16 @@ class TestLiteLLMIntegration:
         assert result == "Generated content"
         mock_completion.assert_called_once()
     
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key", "ANTHROPIC_API_KEY": "test-key"})
     def test_model_validation(self):
         """Test model format validation."""
-        # Valid formats
+        # Valid formats (with mocked env vars)
         assert validate_model_config("openai/gpt-4o")[0] == True
         assert validate_model_config("anthropic/claude-3-5-sonnet-20241022")[0] == True
+        
+        # Valid formats that don't need API keys
+        assert validate_model_config("ollama/llama3.1")[0] == True
+        assert validate_model_config("vllm/meta-llama/Llama-3-8b-chat-hf")[0] == True
         
         # Invalid formats
         assert validate_model_config("invalid-format")[0] == False

--- a/tests/jpl/slim/utils/test_ai_utils.py
+++ b/tests/jpl/slim/utils/test_ai_utils.py
@@ -91,13 +91,16 @@ class TestAIUtils:
         assert 'Reference content' in result
         assert 'Additional comment' in result
 
+    @patch('jpl.slim.utils.ai_utils.generate_with_litellm')
     @patch('jpl.slim.utils.ai_utils.generate_with_openai')
-    def test_generate_content_openai(self, mock_generate_openai):
+    def test_generate_content_openai(self, mock_generate_openai, mock_generate_litellm):
         """Test generating content with OpenAI."""
         # Arrange
         prompt = 'Test prompt'
         model = 'openai/gpt-4o'
         
+        # Make litellm fail so it falls back to legacy implementation
+        mock_generate_litellm.side_effect = Exception("LiteLLM not available")
         mock_generate_openai.return_value = iter(['AI', '-', 'generated', ' ', 'content'])
         
         # Act
@@ -107,13 +110,16 @@ class TestAIUtils:
         mock_generate_openai.assert_called_once_with(prompt, 'gpt-4o')
         assert result == 'AI-generated content'
 
+    @patch('jpl.slim.utils.ai_utils.generate_with_litellm')
     @patch('jpl.slim.utils.ai_utils.generate_with_azure')
-    def test_generate_content_azure(self, mock_generate_azure):
+    def test_generate_content_azure(self, mock_generate_azure, mock_generate_litellm):
         """Test generating content with Azure."""
         # Arrange
         prompt = 'Test prompt'
         model = 'azure/gpt-4o'
         
+        # Make litellm fail so it falls back to legacy implementation
+        mock_generate_litellm.side_effect = Exception("LiteLLM not available")
         mock_generate_azure.return_value = 'AI-generated content'
         
         # Act
@@ -123,13 +129,16 @@ class TestAIUtils:
         mock_generate_azure.assert_called_once_with(prompt, 'gpt-4o')
         assert result == 'AI-generated content'
 
+    @patch('jpl.slim.utils.ai_utils.generate_with_litellm')
     @patch('jpl.slim.utils.ai_utils.generate_with_ollama')
-    def test_generate_content_ollama(self, mock_generate_ollama):
+    def test_generate_content_ollama(self, mock_generate_ollama, mock_generate_litellm):
         """Test generating content with Ollama."""
         # Arrange
         prompt = 'Test prompt'
         model = 'ollama/llama3.3'
         
+        # Make litellm fail so it falls back to legacy implementation
+        mock_generate_litellm.side_effect = Exception("LiteLLM not available")
         mock_generate_ollama.return_value = 'AI-generated content'
         
         # Act

--- a/tests/jpl/slim/utils/test_helpers.py
+++ b/tests/jpl/slim/utils/test_helpers.py
@@ -1,0 +1,42 @@
+"""
+Tests for helper functions in the docgen utils module.
+"""
+
+import pytest
+from jpl.slim.docgen.utils.helpers import escape_yaml_value
+
+
+class TestEscapeYamlValue:
+    """Test the escape_yaml_value function."""
+    
+    def test_empty_string(self):
+        """Test that empty strings are properly handled."""
+        assert escape_yaml_value("") == '""'
+        assert escape_yaml_value(None) == '""'
+    
+    def test_simple_string(self):
+        """Test that simple strings without special characters are returned as-is."""
+        assert escape_yaml_value("simple") == "simple"
+        assert escape_yaml_value("hello world") == "hello world"
+    
+    def test_title_with_colon(self):
+        """Test that title strings with colons are properly quoted."""
+        assert escape_yaml_value("Introduction: Getting Started") == '"Introduction: Getting Started"'
+        assert escape_yaml_value("Step 1: Install Dependencies") == '"Step 1: Install Dependencies"'
+        assert escape_yaml_value("Error: File not found") == '"Error: File not found"'
+        assert escape_yaml_value("TODO: Add more tests") == '"TODO: Add more tests"'
+    
+    def test_yaml_special_cases(self):
+        """Test strings that could be misinterpreted as YAML structures."""
+        assert escape_yaml_value("key: value") == '"key: value"'
+        assert escape_yaml_value("[item1, item2]") == '"[item1, item2]"'
+        assert escape_yaml_value("{key: value}") == '"{key: value}"'
+        assert escape_yaml_value("@directive") == '"@directive"'
+        assert escape_yaml_value("|multiline") == '"|multiline"'
+        assert escape_yaml_value(">folded") == '">folded"'
+    
+    def test_quotes_in_titles(self):
+        """Test that titles with quotes are properly escaped."""
+        assert escape_yaml_value('The "Best" Practices') == '"The \\"Best\\" Practices"'
+        assert escape_yaml_value("User's Guide") == '"User\'s Guide"'
+        assert escape_yaml_value('Section: "How to" Guide') == '"Section: \\"How to\\" Guide"'


### PR DESCRIPTION
## Purpose
- Ensure all unit tests pass
- Fix doc-gen issue of placing colon in title of Markdown files, which causes build errors
## Proposed Changes
- [CHANGE] Unit tests
- [ADD] New function to safely process / escape YAML inserted strings
## Issues
- See: https://github.com/NASA-AMMOS/slim-cli/pull/35#pullrequestreview-2899056093
## Testing
- Unit tests pass
- doc-gen tested successfully (builds fine first time) with: `slim apply --best-practice-ids doc-gen --repo-dir /tmp/MMTC --output-dir /tmp/mmtc-site --use-ai anthropic/claude-3-5-sonnet-20241022`