### PR TITLE
Alias support in slim-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,55 +142,55 @@ To specify a logging level for the app, choose between `DEBUG`, `INFO` (default)
 
 2. **Apply best practices to repositories**
    - This command applies specified best practices to one or more repositories. It supports applying multiple practices simultaneously across multiple repositories, with AI customization options available.
-   - `--best-practice-ids`: List of best practice IDs to apply.
+   - `--best-practices`: List of best practice aliases to apply (e.g., `readme`, `governance-small`, `secrets-github`).
    - `--repo-urls`: List of repository URLs to apply the best practices to; not used if `--repo-dir` is specified.
    - `--repo-dir`: Local directory path of the repository where the best practices will be applied.
    - `--clone-to-dir`: Path where the repository should be cloned if not present locally. Compatible with `--repo-urls`.
    - `--use-ai`: Enables AI features to customize the application of best practices based on the project’s specific needs. Specify the model provider and model name as an argument (e.g., `azure/gpt-4o`).
    ```bash
-   slim apply --best-practice-ids SLIM-123 SLIM-456 --repo-urls https://github.com/your-username/your-repo1 https://github.com/your-username/your-repo2 
+   slim apply --best-practices readme governance-small --repo-urls https://github.com/your-username/your-repo1 https://github.com/your-username/your-repo2 
    ```
    - To apply a best practice using AI customization:
    ```bash
    # Apply a specific best practice using AI customization
-   slim apply --best-practice-ids SLIM-123 --repo-urls https://github.com/your_org/your_repo.git --use-ai <model provider>/<model name>
+   slim apply --best-practices readme --repo-urls https://github.com/your_org/your_repo.git --use-ai <model provider>/<model name>
    ```
    Example usage: 
    ```bash
    # Apply and deploy a best practice using Azure's GPT-4o model
-   slim apply --best-practice-ids SLIM-3.1 --repo-urls https://github.com/riverma/terraformly/ --use-ai azure/gpt-4o
+   slim apply --best-practices governance-small --repo-urls https://github.com/riverma/terraformly/ --use-ai azure/gpt-4o
    ```
    ```bash
    # Apply and deploy a best practice using Ollama's LLaMA 3.1 model
-   slim apply --best-practice-ids SLIM-3.1 --repo-urls https://github.com/riverma/terraformly/ --use-ai ollama/gemma3
+   slim apply --best-practices governance-small --repo-urls https://github.com/riverma/terraformly/ --use-ai ollama/gemma3
    ```
    
 3. **Deploy a best practice**
    - After applying best practices, you may want to deploy (commit and push) them to a remote repository.
-   - `--best-practice-ids`: List of best practice IDs that have been applied and are ready for deployment.
+   - `--best-practices`: List of best practice aliases that have been applied and are ready for deployment.
    - `--repo-dir`: The local directory of the repository where changes will be committed and pushed.
    - `--remote-name`: Specifies the remote name in the git configuration to which the changes will be pushed.
    - `--commit-message`: A message describing the changes for the commit.
    ```bash
-   slim deploy --best-practice-ids SLIM-123 SLIM-456 --repo-dir /path/to/repo --remote-name origin --commit-message "Apply SLIM best practices"
+   slim deploy --best-practices readme governance-small --repo-dir /path/to/repo --remote-name origin --commit-message "Apply SLIM best practices"
    ```
 
 4. **Apply and deploy a best practice**
    - Combines the application and deployment of a best practice into one step.
-   - `--best-practice-ids`: List of best practice IDs to apply and then deploy.
+   - `--best-practices`: List of best practice aliases to apply and then deploy.
    - `--repo-urls`: List of repository URLs for cloning if not already cloned; not used if `--repo-dir` is specified.
    - `--repo-dir`: Specifies the directory of the repository where the best practice will be applied and changes committed.
    - `--remote-name`: Specifies the remote to which the changes will be pushed. Format should be a GitHub-like URL base. For example `https://github.com/my_github_user`
    - `--commit-message`: A message describing the changes for the commit.
    - `--use-ai`: If specified, enables AI customization of the best practice before applying. False by default.
    ```bash
-   slim apply-deploy --best-practice-ids SLIM-123 --repo-urls https://github.com/your-username/your-repo1 https://github.com/your-username/your-repo2 --remote-name origin --commit-message "Integrated SLIM best practice with AI customization"
+   slim apply-deploy --best-practices readme --repo-urls https://github.com/your-username/your-repo1 https://github.com/your-username/your-repo2 --remote-name origin --commit-message "Integrated SLIM best practice with AI customization"
    ```
    Example output:
    ```
    AI features disabled
-   Applied best practice SLIM-123 and committed to branch slim-123
-   Pushed changes to remote origin on branch slim-123
+   Applied best practice readme and committed to branch readme
+   Pushed changes to remote origin on branch readme
    ```
 
 5. **Generate documentation**
@@ -205,19 +205,19 @@ To specify a logging level for the app, choose between `DEBUG`, `INFO` (default)
    
    **Template-Only Mode** - Generate just the template structure without analyzing a repository:
    ```bash
-   slim apply --best-practice-ids doc-gen --template-only --output-dir ../docs-site
+   slim apply --best-practices docs-website --template-only --output-dir ../docs-site
    ```
    
    **AI-Enhanced Documentation** (Recommended approach):
    ```bash
    # Using OpenAI (recommended for quality)
-   slim apply --best-practice-ids doc-gen --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai openai/gpt-4o
+   slim apply --best-practices docs-website --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai openai/gpt-4o
    
    # Using Azure OpenAI (recommended for enterprise)
-   slim apply --best-practice-ids doc-gen --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai azure/gpt-4o
+   slim apply --best-practices docs-website --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai azure/gpt-4o
    
    # Using local models (basic quality, not recommended for production)
-   slim apply --best-practice-ids doc-gen --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai ollama/gemma3
+   slim apply --best-practices docs-website --repo-dir /path/to/your/repo --output-dir /path/to/output --use-ai ollama/gemma3
 
    # Explore available AI models
    slim models list
@@ -227,16 +227,16 @@ To specify a logging level for the app, choose between `DEBUG`, `INFO` (default)
    
    Example usage:
    ```bash
-   slim apply --best-practice-ids doc-gen --repo-dir ./hysds --output-dir ./hysds-docs-site --use-ai openai/gpt-4o
+   slim apply --best-practices docs-website --repo-dir ./hysds --output-dir ./hysds-docs-site --use-ai openai/gpt-4o
    ```
    
    **Revising an Existing Site**:
    ```bash
    # With cloud models (recommended)
-   slim apply --best-practice-ids doc-gen --revise-site --repo-dir /path/to/your/repo --output-dir ./docs-site --use-ai openai/gpt-4o
+   slim apply --best-practices docs-website --revise-site --repo-dir /path/to/your/repo --output-dir ./docs-site --use-ai openai/gpt-4o
    
    # With local models (basic quality)
-   slim apply --best-practice-ids doc-gen --revise-site --repo-dir /path/to/your/repo --output-dir ./docs-site --use-ai ollama/gemma3
+   slim apply --best-practices docs-website --revise-site --repo-dir /path/to/your/repo --output-dir ./docs-site --use-ai ollama/gemma3
    ```
    
    **Generated Content**

--- a/src/jpl/slim/best_practices/base.py
+++ b/src/jpl/slim/best_practices/base.py
@@ -32,7 +32,7 @@ class BestPractice(ABC):
         self.description = description
 
     @abstractmethod
-    def apply(self, repo_path, use_ai=False, model=None, repo_url=None, target_dir_to_clone_to=None, branch=None, no_prompt=False):
+    def apply(self, repo_path, use_ai=False, model=None, repo_url=None, target_dir_to_clone_to=None, branch=None, no_prompt=False, **kwargs):
         """
         Apply the best practice to a repository.
 
@@ -44,6 +44,7 @@ class BestPractice(ABC):
             target_dir_to_clone_to (str, optional): Directory to clone repository to. Defaults to None.
             branch (str, optional): Git branch to use. Defaults to None.
             no_prompt (bool, optional): Skip user confirmation prompts for dependencies installation. Defaults to False.
+            **kwargs: Additional keyword arguments for specific practice implementations.
 
         Raises:
             NotImplementedError: If the method is not implemented by a subclass

--- a/src/jpl/slim/best_practices/docgen.py
+++ b/src/jpl/slim/best_practices/docgen.py
@@ -34,7 +34,7 @@ class DocGenPractice(BestPractice):
     def __init__(self):
         """Initialize the documentation generation best practice."""
         super().__init__(
-            best_practice_id="doc-gen",
+            best_practice_id="docs-website",
             uri="https://github.com/NASA-AMMOS/slim-docsite-template.git",
             title="Documentation Generator",
             description="Generates comprehensive documentation sites for software projects using the SLIM docsite template and AI enhancement"
@@ -93,16 +93,21 @@ class DocGenPractice(BestPractice):
             if success:
                 if template_only:
                     logging.info(f"Template structure successfully generated at {output_dir}")
+                    print(f"✅ Successfully generated documentation template at {output_dir}")
                 else:
                     logging.info(f"Documentation successfully generated at {output_dir}")
+                    print(f"✅ Successfully generated documentation at {output_dir}")
+                print(f"   📁 Source repository: {repo_path}")
                 return repo_path
             else:
                 logging.error("Documentation generation failed")
+                print(f"❌ Failed to generate documentation for best practice '{self.best_practice_id}'")
                 return None
                 
         except Exception as e:
             logging.error(f"Error generating documentation: {str(e)}")
             logging.debug(traceback.format_exc())
+            print(f"❌ Error generating documentation: {str(e)}")
             return None
     
     def deploy(self, repo_path, remote=None, commit_message=None):

--- a/src/jpl/slim/best_practices/practice_mapping.py
+++ b/src/jpl/slim/best_practices/practice_mapping.py
@@ -1,0 +1,153 @@
+"""
+Practice mapping module for SLIM best practices.
+
+This module defines the mapping between aliases and practice classes,
+following DRY principles for consistent alias-to-implementation mapping
+across the SLIM CLI codebase.
+"""
+
+# Practice class names as strings to avoid circular imports
+PRACTICE_CLASS_STANDARD = 'StandardPractice'
+PRACTICE_CLASS_SECRETS = 'SecretsDetection'
+PRACTICE_CLASS_DOCGEN = 'DocGenPractice'
+
+# Mapping from aliases to practice class names
+ALIAS_TO_PRACTICE_CLASS = {
+    # Governance practices (StandardPractice)
+    'governance-small': PRACTICE_CLASS_STANDARD,
+    'governance-medium': PRACTICE_CLASS_STANDARD,
+    'governance-large': PRACTICE_CLASS_STANDARD,
+    'code-of-conduct': PRACTICE_CLASS_STANDARD,
+    'code-of-conduct-collab': PRACTICE_CLASS_STANDARD,
+    'contributing': PRACTICE_CLASS_STANDARD,
+    'issue-bug-md': PRACTICE_CLASS_STANDARD,
+    'issue-bug-form': PRACTICE_CLASS_STANDARD,
+    'issue-feature-md': PRACTICE_CLASS_STANDARD,
+    'issue-feature-form': PRACTICE_CLASS_STANDARD,
+    'pull-request': PRACTICE_CLASS_STANDARD,
+    'codeowners': PRACTICE_CLASS_STANDARD,
+    'license-apache-jpl': PRACTICE_CLASS_STANDARD,
+    'license-mit-jpl': PRACTICE_CLASS_STANDARD,
+    'license-apache': PRACTICE_CLASS_STANDARD,
+    'license-mit': PRACTICE_CLASS_STANDARD,
+    
+    # Documentation practices (StandardPractice)
+    'readme': PRACTICE_CLASS_STANDARD,
+    'changelog': PRACTICE_CLASS_STANDARD,
+    'testing-plan': PRACTICE_CLASS_STANDARD,
+    
+    # Security practices (SecretsDetection)
+    'secrets-github': PRACTICE_CLASS_SECRETS,
+    'secrets-precommit': PRACTICE_CLASS_SECRETS,
+    
+    # Testing practices (StandardPractice)
+    'static-tests-precommit': PRACTICE_CLASS_STANDARD,
+    'container-scan-precommit': PRACTICE_CLASS_STANDARD,
+    
+    # Documentation generation (DocGenPractice)
+    'docs-website': PRACTICE_CLASS_DOCGEN,
+}
+
+# Mapping for StandardPractice file paths based on aliases
+ALIAS_TO_FILE_PATH = {
+    'governance-small': 'GOVERNANCE.md',
+    'governance-medium': 'GOVERNANCE.md',
+    'governance-large': 'GOVERNANCE.md',
+    'readme': 'README.md',
+    'issue-bug-md': '.github/ISSUE_TEMPLATE/bug_report.md',
+    'issue-bug-form': '.github/ISSUE_TEMPLATE/bug_report.yml',
+    'issue-feature-md': '.github/ISSUE_TEMPLATE/new_feature.md',
+    'issue-feature-form': '.github/ISSUE_TEMPLATE/new_feature.yml',
+    'changelog': 'CHANGELOG.md',
+    'pull-request': '.github/PULL_REQUEST_TEMPLATE.md',
+    'codeowners': '.github/CODEOWNERS',
+    'code-of-conduct': 'CODE_OF_CONDUCT.md',
+    'code-of-conduct-collab': 'CODE_OF_COLLAB.md',
+    'license-apache-jpl': 'LICENSE',
+    'license-mit-jpl': 'LICENSE',
+    'license-apache': 'LICENSE',
+    'license-mit': 'LICENSE',
+    'contributing': 'CONTRIBUTING.md',
+    'testing-plan': 'TESTING.md',
+    'static-tests-precommit': '.pre-commit-config.yaml',
+    'container-scan-precommit': '.pre-commit-config.yml',
+}
+
+# AI generation mapping for aliases (for ai_utils.py)
+ALIAS_AI_CONTEXT = {
+    'governance-small': 'governance',
+    'governance-medium': 'governance', 
+    'governance-large': 'governance',
+    'readme': 'readme',
+    'testing-plan': 'testing',
+    # Other aliases use default context
+}
+
+def get_practice_class_name(alias: str):
+    """
+    Get the practice class name for a given alias.
+    
+    Args:
+        alias: The practice alias
+        
+    Returns:
+        The practice class name as string, or None if not found
+    """
+    return ALIAS_TO_PRACTICE_CLASS.get(alias)
+
+def get_file_path(alias: str):
+    """
+    Get the file path for a StandardPractice alias.
+    
+    Args:
+        alias: The practice alias
+        
+    Returns:
+        The file path, or None if not found
+    """
+    return ALIAS_TO_FILE_PATH.get(alias)
+
+def get_ai_context_type(alias: str):
+    """
+    Get the AI context type for a given alias.
+    
+    Args:
+        alias: The practice alias
+        
+    Returns:
+        The AI context type, or 'default' if not specified
+    """
+    return ALIAS_AI_CONTEXT.get(alias, 'default')
+
+def is_secrets_detection_practice(alias: str):
+    """
+    Check if an alias is for a secrets detection practice.
+    
+    Args:
+        alias: The practice alias
+        
+    Returns:
+        True if it's a secrets detection practice, False otherwise
+    """
+    return ALIAS_TO_PRACTICE_CLASS.get(alias) == PRACTICE_CLASS_SECRETS
+
+def is_docgen_practice(alias: str):
+    """
+    Check if an alias is for a documentation generation practice.
+    
+    Args:
+        alias: The practice alias
+        
+    Returns:
+        True if it's a documentation generation practice, False otherwise
+    """
+    return ALIAS_TO_PRACTICE_CLASS.get(alias) == PRACTICE_CLASS_DOCGEN
+
+def get_all_aliases():
+    """
+    Get all available aliases.
+    
+    Returns:
+        List of all available aliases
+    """
+    return list(ALIAS_TO_PRACTICE_CLASS.keys())

--- a/src/jpl/slim/best_practices/secrets_detection.py
+++ b/src/jpl/slim/best_practices/secrets_detection.py
@@ -21,14 +21,14 @@ SLIM_TEST_MODE = os.environ.get('SLIM_TEST_MODE', 'False').lower() in ('true', '
 
 class SecretsDetection(StandardPractice):
     """
-    Best practice for secrets detection implementation (SLIM-2.1 and SLIM-2.2).
+    Best practice for secrets detection implementation (secrets-github and secrets-precommit).
 
     This class handles setting up secrets detection tools like detect-secrets
     and pre-commit hooks in repositories.
     """
 
     def apply(self, repo_path, use_ai=False, model=None, repo_url=None,
-              target_dir_to_clone_to=None, branch=None, no_prompt=False):
+              target_dir_to_clone_to=None, branch=None, no_prompt=False, **kwargs):
         """
         Apply the secrets detection best practice to a repository.
 
@@ -56,8 +56,8 @@ class SecretsDetection(StandardPractice):
         if not git_repo:
             return None
 
-        # Process best practice by ID
-        if self.best_practice_id == 'SLIM-2.1':
+        # Process best practice by alias
+        if self.best_practice_id == 'secrets-github':
             # Create .github/workflows directory if it doesn't exist
             workflows_dir = os.path.join(git_repo.working_dir, '.github', 'workflows')
             os.makedirs(workflows_dir, exist_ok=True)
@@ -95,12 +95,16 @@ class SecretsDetection(StandardPractice):
                         else:
                             logging.warning("Not running detect-secrets scan. Assuming you have a `.secrets-baseline` file present in your repo already.")
 
+                print(f"✅ Successfully applied best practice '{self.best_practice_id}' to repository")
+                print(f"   📁 Repository: {git_repo.working_dir}")
+                print(f"   🌿 Branch: {git_branch.name}")
                 return git_repo
             else:
                 logging.error(f"Failed to apply best practice {self.best_practice_id}")
+                print(f"❌ Failed to apply best practice '{self.best_practice_id}'")
                 return None
 
-        elif self.best_practice_id == 'SLIM-2.2':
+        elif self.best_practice_id == 'secrets-precommit':
             # Install pre-commit if not in test mode
             if not SLIM_TEST_MODE:
                 if no_prompt:
@@ -162,12 +166,17 @@ class SecretsDetection(StandardPractice):
                         elif not os.path.exists(baseline_file):
                             logging.warning("Not running detect-secrets scan. No .secrets.baseline file is present in your repo.")
 
+                print(f"✅ Successfully applied best practice '{self.best_practice_id}' to repository")
+                print(f"   📁 Repository: {git_repo.working_dir}")
+                print(f"   🌿 Branch: {git_branch.name}")
                 return git_repo
             else:
                 logging.error(f"Failed to apply best practice {self.best_practice_id}")
+                print(f"❌ Failed to apply best practice '{self.best_practice_id}'")
                 return None
         else:
             logging.warning(f"SLIM best practice {self.best_practice_id} not supported.")
+            print(f"❌ Best practice '{self.best_practice_id}' is not supported by SecretsDetection")
             return None
 
     def deploy(self, repo_path, remote=None, commit_message=None):
@@ -186,9 +195,9 @@ class SecretsDetection(StandardPractice):
 
         # Set custom commit message for secrets detection best practices
         if not commit_message:
-            if self.best_practice_id == 'SLIM-2.1':
+            if self.best_practice_id == 'secrets-github':
                 commit_message = "Add detect-secrets workflow"
-            elif self.best_practice_id == 'SLIM-2.2':
+            elif self.best_practice_id == 'secrets-precommit':
                 commit_message = "Add pre-commit configuration"
             else:
                 commit_message = f"Add secrets detection for {self.best_practice_id}"

--- a/src/jpl/slim/best_practices/standard.py
+++ b/src/jpl/slim/best_practices/standard.py
@@ -14,6 +14,7 @@ import uuid
 import git
 
 from jpl.slim.best_practices.base import BestPractice
+from jpl.slim.best_practices.practice_mapping import get_file_path
 from jpl.slim.utils.io_utils import download_and_place_file
 from jpl.slim.utils.ai_utils import generate_with_ai
 # Import the constant directly to avoid circular imports
@@ -131,7 +132,7 @@ class StandardPractice(BestPractice):
             return None, None, None
             
     def apply(self, repo_path, use_ai=False, model=None, repo_url=None,
-              target_dir_to_clone_to=None, branch=None, no_prompt=False):
+              target_dir_to_clone_to=None, branch=None, no_prompt=False, **kwargs):
         """
         Apply the standard best practice to a repository.
 
@@ -169,36 +170,13 @@ class StandardPractice(BestPractice):
         if not git_repo:
             return None
 
-        # Process best practice by ID
-        if self.best_practice_id == 'SLIM-1.1':
-            applied_file_path = download_and_place_file(git_repo, self.uri, 'GOVERNANCE.md')
-        elif self.best_practice_id == 'SLIM-1.2':
-            applied_file_path = download_and_place_file(git_repo, self.uri, 'GOVERNANCE.md')
-        elif self.best_practice_id == 'SLIM-1.3':
-            applied_file_path = download_and_place_file(git_repo, self.uri, 'GOVERNANCE.md')
-        elif self.best_practice_id == 'SLIM-3.1':
-            applied_file_path = download_and_place_file(git_repo, self.uri, 'README.md')
-        elif self.best_practice_id == 'SLIM-4.1':
-            applied_file_path = download_and_place_file(git_repo, self.uri, '.github/ISSUE_TEMPLATE/bug_report.md')
-        elif self.best_practice_id == 'SLIM-4.2':
-            applied_file_path = download_and_place_file(git_repo, self.uri, '.github/ISSUE_TEMPLATE/bug_report.yml')
-        elif self.best_practice_id == 'SLIM-4.3':
-            applied_file_path = download_and_place_file(git_repo, self.uri, '.github/ISSUE_TEMPLATE/new_feature.md')
-        elif self.best_practice_id == 'SLIM-4.4':
-            applied_file_path = download_and_place_file(git_repo, self.uri, '.github/ISSUE_TEMPLATE/new_feature.yml')
-        elif self.best_practice_id == 'SLIM-5.1':
-            applied_file_path = download_and_place_file(git_repo, self.uri, 'CHANGELOG.md')
-        elif self.best_practice_id == 'SLIM-7.1':
-            applied_file_path = download_and_place_file(git_repo, self.uri, '.github/PULL_REQUEST_TEMPLATE.md')
-        elif self.best_practice_id == 'SLIM-8.1':
-            applied_file_path = download_and_place_file(git_repo, self.uri, 'CODE_OF_CONDUCT.md')
-        elif self.best_practice_id == 'SLIM-9.1':
-            applied_file_path = download_and_place_file(git_repo, self.uri, 'CONTRIBUTING.md')
-        elif self.best_practice_id == 'SLIM-13.1':
-            applied_file_path = download_and_place_file(git_repo, self.uri, 'TESTING.md')
+        # Process best practice by alias
+        file_path = get_file_path(self.best_practice_id)
+        if file_path:
+            applied_file_path = download_and_place_file(git_repo, self.uri, file_path)
         else:
             applied_file_path = None  # nothing was modified
-            logging.warning(f"SLIM best practice {self.best_practice_id} not supported.")
+            logging.warning(f"Best practice {self.best_practice_id} not supported or no file mapping found.")
 
         # Apply AI customization if requested
         if applied_file_path and use_ai and model:
@@ -206,9 +184,13 @@ class StandardPractice(BestPractice):
 
         if applied_file_path:
             logging.info(f"Applied best practice {self.best_practice_id} to local repo {git_repo.working_tree_dir} and branch '{git_branch.name}'")
+            print(f"✅ Successfully applied best practice '{self.best_practice_id}' to repository")
+            print(f"   📁 Repository: {git_repo.working_tree_dir}")
+            print(f"   🌿 Branch: {git_branch.name}")
             return git_repo  # return the modified git repo object
         else:
             logging.error(f"Failed to apply best practice {self.best_practice_id}")
+            print(f"❌ Failed to apply best practice '{self.best_practice_id}'")
             return None
 
     def _apply_ai_customization(self, git_repo, file_path, model):

--- a/src/jpl/slim/cli.py
+++ b/src/jpl/slim/cli.py
@@ -198,23 +198,23 @@ def show_model_help():
     print()
     
     print("Premium Quality (Recommended for Production):")
-    print("  slim apply --best-practice-ids doc-gen --use-ai anthropic/claude-3-5-sonnet-20241022 [...]")
-    print("  slim apply --best-practice-ids doc-gen --use-ai openai/gpt-4o [...]")
+    print("  slim apply --best-practice-ids docs-website --use-ai anthropic/claude-3-5-sonnet-20241022 [...]")
+    print("  slim apply --best-practice-ids docs-website --use-ai openai/gpt-4o [...]")
     print()
     
     print("Balanced Quality/Cost:")
-    print("  slim apply --best-practice-ids doc-gen --use-ai openai/gpt-4o-mini [...]")
-    print("  slim apply --best-practice-ids doc-gen --use-ai cohere/command-r [...]")
+    print("  slim apply --best-practice-ids docs-website --use-ai openai/gpt-4o-mini [...]")
+    print("  slim apply --best-practice-ids docs-website --use-ai cohere/command-r [...]")
     print()
     
     print("Fast & Affordable:")
-    print("  slim apply --best-practice-ids doc-gen --use-ai groq/llama-3.1-70b-versatile [...]")
-    print("  slim apply --best-practice-ids doc-gen --use-ai together/meta-llama/Llama-3-8b-chat-hf [...]")
+    print("  slim apply --best-practice-ids docs-website --use-ai groq/llama-3.1-70b-versatile [...]")
+    print("  slim apply --best-practice-ids docs-website --use-ai together/meta-llama/Llama-3-8b-chat-hf [...]")
     print()
     
     print("Local/Offline:")
-    print("  slim apply --best-practice-ids doc-gen --use-ai ollama/llama3.1 [...]")
-    print("  slim apply --best-practice-ids doc-gen --use-ai vllm/meta-llama/Llama-3-8b-chat-hf [...]")
+    print("  slim apply --best-practice-ids docs-website --use-ai ollama/llama3.1 [...]")
+    print("  slim apply --best-practice-ids docs-website --use-ai vllm/meta-llama/Llama-3-8b-chat-hf [...]")
     print()
     
     print("For more models and setup instructions:")
@@ -277,16 +277,16 @@ def handle_special_cases(args):
         show_model_help()
         sys.exit(1)
     
-    # If user is applying doc-gen without output-dir
+    # If user is applying docs-website without output-dir
     if (hasattr(args, 'best_practice_ids') and 
         args.best_practice_ids and 
-        'doc-gen' in args.best_practice_ids and 
+        'docs-website' in args.best_practice_ids and 
         not getattr(args, 'output_dir', None) and
         not getattr(args, 'template_only', False)):
         print("❌ Error: --output-dir is required for documentation generation")
         print()
         print("Example:")
-        print("  slim apply --best-practice-ids doc-gen --repo-dir ./my-project --output-dir ./docs")
+        print("  slim apply --best-practice-ids docs-website --repo-dir ./my-project --output-dir ./docs")
         sys.exit(1)
 
 
@@ -312,7 +312,7 @@ Examples:
   slim list
 
   # Apply documentation generation with AI
-  slim apply --best-practice-ids doc-gen --repo-dir ./my-project --output-dir ./docs --use-ai openai/gpt-4o-mini
+  slim apply --best-practice-ids docs-website --repo-dir ./my-project --output-dir ./docs --use-ai openai/gpt-4o-mini
 
   # See available AI models
   slim models list

--- a/src/jpl/slim/commands/apply_command.py
+++ b/src/jpl/slim/commands/apply_command.py
@@ -39,7 +39,7 @@ def setup_parser(subparsers):
     from jpl.slim.commands.common import SUPPORTED_MODELS, get_ai_model_pairs
 
     parser = subparsers.add_parser('apply', help='Applies a best practice, i.e. places a best practice in a git repo in the right spot with appropriate content')
-    parser.add_argument('--best-practice-ids', nargs='+', required=True, help='Best practice IDs to apply')
+    parser.add_argument('--best-practices', nargs='+', required=True, help='Best practice aliases to apply (e.g., readme, governance-small, secrets-github)')
     parser.add_argument('--repo-urls', nargs='+', required=False, help='Repository URLs to apply to. Do not use if --repo-dir specified')
     parser.add_argument('--repo-urls-file', required=False, help='Path to a file containing repository URLs')
     parser.add_argument('--repo-dir', required=False, help='Repository directory location on local machine. Only one repository supported')
@@ -48,9 +48,9 @@ def setup_parser(subparsers):
     parser.add_argument('--no-prompt', action='store_true', help='Skip user confirmation prompts when installing dependencies')
     
     # Document generator specific arguments
-    parser.add_argument('--output-dir', required=False, help='Output directory for generated documentation (required for doc-gen)')
-    parser.add_argument('--template-only', action='store_true', help='Generate only the documentation template without analyzing a repository (for doc-gen)')
-    parser.add_argument('--revise-site', action='store_true', help='Revise an existing documentation site (for doc-gen)')
+    parser.add_argument('--output-dir', required=False, help='Output directory for generated documentation (required for docs-website)')
+    parser.add_argument('--template-only', action='store_true', help='Generate only the documentation template without analyzing a repository (for docs-website)')
+    parser.add_argument('--revise-site', action='store_true', help='Revise an existing documentation site (for docs-website)')
     
     parser.set_defaults(func=handle_command)
     return parser
@@ -67,7 +67,7 @@ def handle_command(args):
     """
     # Clean argument extraction - no more brittle popping!
     apply_best_practices(
-        best_practice_ids=args.best_practice_ids,
+        best_practice_ids=args.best_practices,
         use_ai_flag=bool(args.use_ai),
         model=args.use_ai,
         repo_urls=repo_file_to_list(args.repo_urls_file) if args.repo_urls_file else args.repo_urls,
@@ -95,8 +95,8 @@ def apply_best_practices(best_practice_ids, use_ai_flag, model, repo_urls=None, 
         no_prompt: Skip user confirmation prompts for dependencies installation
         **kwargs: Additional arguments (output_dir, template_only, revise_site, etc.)
     """
-    # Handle special case for doc-gen best practice
-    if len(best_practice_ids) == 1 and best_practice_ids[0] == "doc-gen":
+    # Handle special case for docs-website best practice
+    if len(best_practice_ids) == 1 and best_practice_ids[0] == "docs-website":
         apply_best_practice(
             best_practice_id=best_practice_ids[0],
             use_ai_flag=use_ai_flag,

--- a/src/jpl/slim/commands/apply_deploy_command.py
+++ b/src/jpl/slim/commands/apply_deploy_command.py
@@ -43,7 +43,7 @@ def setup_parser(subparsers):
     from jpl.slim.commands.common import SUPPORTED_MODELS, get_ai_model_pairs
 
     parser = subparsers.add_parser('apply-deploy', help='Applies and deploys a best practice')
-    parser.add_argument('--best-practice-ids', nargs='+', required=True, help='Best practice IDs to apply')
+    parser.add_argument('--best-practices', nargs='+', required=True, help='Best practice aliases to apply (e.g., readme, governance-small, secrets-github)')
     parser.add_argument('--repo-urls', nargs='+', required=False, help='Repository URLs to apply to. Do not use if --repo-dir specified')
     parser.add_argument('--repo-urls-file', required=False, help='Path to a file containing repository URLs')
     parser.add_argument('--repo-dir', required=False, help='Repository directory location on local machine. Only one repository supported')
@@ -73,7 +73,7 @@ def handle_command(args):
     """
     # Clean argument extraction - no more brittle popping!
     apply_and_deploy_best_practices(
-        best_practice_ids=args.best_practice_ids,
+        best_practice_ids=args.best_practices,
         use_ai_flag=bool(args.use_ai),
         model=args.use_ai if args.use_ai else None,
         remote=args.remote,

--- a/src/jpl/slim/commands/common.py
+++ b/src/jpl/slim/commands/common.py
@@ -13,8 +13,8 @@ from typing import Dict, List, Any, Tuple
 # Constants
 SLIM_REGISTRY_URI = "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/data/slim-registry.json"
 
-# Documentation practice aliases - both should work
-DOCUMENTATION_PRACTICE_IDS = {'doc-gen', 'SLIM-18.1'}
+# Documentation practice aliases
+DOCUMENTATION_PRACTICE_IDS = {'docs-website'}
 
 # LiteLLM supported models organized by provider and use case
 SUPPORTED_MODELS = {
@@ -492,11 +492,11 @@ def print_model_recommendations():
     
     print("\n💡 Usage Examples:")
     print("  # Premium quality documentation")
-    print("  slim apply --best-practice-ids doc-gen --use-ai anthropic/claude-3-5-sonnet-20241022 ...")
+    print("  slim apply --best-practices docs-website --use-ai anthropic/claude-3-5-sonnet-20241022 ...")
     print("\n  # Fast generation")
-    print("  slim apply --best-practice-ids doc-gen --use-ai groq/llama-3.1-70b-versatile ...")
+    print("  slim apply --best-practices docs-website --use-ai groq/llama-3.1-70b-versatile ...")
     print("\n  # Local/offline")
-    print("  slim apply --best-practice-ids doc-gen --use-ai ollama/llama3.1 ...")
+    print("  slim apply --best-practices docs-website --use-ai ollama/llama3.1 ...")
     
     print(f"\n📋 Total supported providers: {len(SUPPORTED_MODELS)}")
     print(f"📋 Total model combinations: {len(get_ai_model_pairs())}+")

--- a/src/jpl/slim/commands/deploy_command.py
+++ b/src/jpl/slim/commands/deploy_command.py
@@ -27,7 +27,7 @@ def setup_parser(subparsers):
         The parser for the 'deploy' command
     """
     parser = subparsers.add_parser('deploy', help='Deploys a best practice, i.e. places the best practice in a git repo, adds, commits, and pushes to the git remote.')
-    parser.add_argument('--best-practice-ids', nargs='+', required=True, help='Best practice IDs to deploy')
+    parser.add_argument('--best-practices', nargs='+', required=True, help='Best practice aliases to deploy (e.g., readme, governance-small, secrets-github)')
     parser.add_argument('--repo-dir', required=False, help='Repository directory location on local machine')
     parser.add_argument('--remote', required=False, default=None, help=f"Push to a specified remote name. If not specified, pushes to '{GIT_DEFAULT_REMOTE_NAME}'.")
     parser.add_argument('--commit-message', required=False, default=GIT_DEFAULT_COMMIT_MESSAGE, help=f"Commit message to use for the deployment. Default '{GIT_DEFAULT_COMMIT_MESSAGE}'")
@@ -46,7 +46,7 @@ def handle_command(args):
     """
     # Clean argument extraction - no more brittle popping!
     deploy_best_practices(
-        best_practice_ids=args.best_practice_ids,
+        best_practice_ids=args.best_practices,
         repo_dir=args.repo_dir,
         remote=args.remote,
         commit_message=args.commit_message

--- a/src/jpl/slim/commands/examples.py
+++ b/src/jpl/slim/commands/examples.py
@@ -4,20 +4,20 @@ Example commands and help text for SLIM CLI.
 
 DOCUMENTATION_EXAMPLES = {
     "premium": [
-        "slim apply --best-practice-ids doc-gen --repo-dir ./project --output-dir ./docs --use-ai anthropic/claude-3-5-sonnet-20241022",
-        "slim apply --best-practice-ids doc-gen --repo-dir ./project --output-dir ./docs --use-ai openai/gpt-4o"
+        "slim apply --best-practices doc-gen --repo-dir ./project --output-dir ./docs --use-ai anthropic/claude-3-5-sonnet-20241022",
+        "slim apply --best-practices doc-gen --repo-dir ./project --output-dir ./docs --use-ai openai/gpt-4o"
     ],
     "balanced": [
-        "slim apply --best-practice-ids doc-gen --repo-dir ./project --output-dir ./docs --use-ai openai/gpt-4o-mini",
-        "slim apply --best-practice-ids doc-gen --repo-dir ./project --output-dir ./docs --use-ai cohere/command-r"
+        "slim apply --best-practices doc-gen --repo-dir ./project --output-dir ./docs --use-ai openai/gpt-4o-mini",
+        "slim apply --best-practices doc-gen --repo-dir ./project --output-dir ./docs --use-ai cohere/command-r"
     ],
     "fast": [
-        "slim apply --best-practice-ids doc-gen --repo-dir ./project --output-dir ./docs --use-ai groq/llama-3.1-70b-versatile",
-        "slim apply --best-practice-ids doc-gen --repo-dir ./project --output-dir ./docs --use-ai together/meta-llama/Llama-3-8b-chat-hf"
+        "slim apply --best-practices doc-gen --repo-dir ./project --output-dir ./docs --use-ai groq/llama-3.1-70b-versatile",
+        "slim apply --best-practices doc-gen --repo-dir ./project --output-dir ./docs --use-ai together/meta-llama/Llama-3-8b-chat-hf"
     ],
     "local": [
-        "slim apply --best-practice-ids doc-gen --repo-dir ./project --output-dir ./docs --use-ai ollama/llama3.1",
-        "slim apply --best-practice-ids doc-gen --repo-dir ./project --output-dir ./docs --use-ai vllm/meta-llama/Llama-3-8b-chat-hf"
+        "slim apply --best-practices doc-gen --repo-dir ./project --output-dir ./docs --use-ai ollama/llama3.1",
+        "slim apply --best-practices doc-gen --repo-dir ./project --output-dir ./docs --use-ai vllm/meta-llama/Llama-3-8b-chat-hf"
     ]
 }
 

--- a/src/jpl/slim/commands/list_command.py
+++ b/src/jpl/slim/commands/list_command.py
@@ -45,13 +45,13 @@ def handle_command(args):
 
     console = Console()
     table = Table(show_header=True, header_style="bold magenta", show_lines=True)
-    headers = ["ID", "Title", "Description", "Asset"]
+    headers = ["Alias", "Title", "Description", "Asset"]
     for header in headers:
         table.add_column(header)
 
-    for asset_id, info in asset_mapping.items():
+    for alias, info in asset_mapping.items():
         table.add_row(
-            asset_id, 
+            alias, 
             textwrap.fill(info['title'], width=30), 
             textwrap.fill(info['description'], width=50), 
             textwrap.fill(info['asset_name'], width=20)

--- a/src/jpl/slim/manager/best_practices_manager.py
+++ b/src/jpl/slim/manager/best_practices_manager.py
@@ -10,6 +10,14 @@ from typing import Dict, List, Optional, Any, Union
 from jpl.slim.best_practices.standard import StandardPractice
 from jpl.slim.best_practices.secrets_detection import SecretsDetection
 from jpl.slim.best_practices.docgen import DocGenPractice
+from jpl.slim.best_practices.practice_mapping import (
+    get_practice_class_name,
+    is_docgen_practice,
+    get_all_aliases,
+    PRACTICE_CLASS_STANDARD,
+    PRACTICE_CLASS_SECRETS,
+    PRACTICE_CLASS_DOCGEN
+)
 from jpl.slim.utils.io_utils import create_slim_registry_dictionary
 
 
@@ -36,54 +44,61 @@ class BestPracticeManager:
             # If it's already a dictionary, use it directly
             self.registry_dict = registry
 
-    def get_best_practice(self, bp_id: str) -> Optional[Union[StandardPractice, SecretsDetection, DocGenPractice]]:
+    def get_best_practice(self, alias: str) -> Optional[Union[StandardPractice, SecretsDetection, DocGenPractice]]:
         """
-        Get a best practice by ID.
+        Get a best practice by alias.
 
         Args:
-            bp_id: ID of the best practice to retrieve (e.g., "SLIM-1.1", "doc-gen", "SLIM-18.1")
+            alias: Alias of the best practice to retrieve (e.g., "readme", "secrets-github", "docs-website")
 
         Returns:
             Union[StandardPractice, SecretsDetection, DocGenPractice]: The best practice object if found, None otherwise
         """
-        logging.debug(f"Retrieving best practice with ID: {bp_id}")
+        logging.debug(f"Retrieving best practice with alias: {alias}")
 
-        # Handle both doc-gen and SLIM-18.1 as aliases for the documentation generator
-        if bp_id in ['doc-gen', 'SLIM-18.1']:
+        # Handle docs-website as a special case for DocGenPractice
+        if is_docgen_practice(alias):
             return DocGenPractice()
 
-        # Check if the best practice ID exists in the registry
-        if bp_id not in self.registry_dict:
-            logging.warning(f"Best practice ID {bp_id} not found in registry")
+        # Check if the alias exists in the registry
+        if alias not in self.registry_dict:
+            logging.warning(f"Best practice alias {alias} not found in registry")
             return None
 
         # Get the best practice information from the registry
-        practice_info = self.registry_dict[bp_id]
+        practice_info = self.registry_dict[alias]
 
-        # Determine which asset URI to use based on the best practice ID
+        # Get metadata
         uri = practice_info.get('asset_uri', '')
         title = practice_info.get('title', '')
         description = practice_info.get('description', '')
 
-        # Determine the appropriate practice type based on the best practice ID
-        if bp_id in ['SLIM-1.1', 'SLIM-1.2', 'SLIM-1.3', 'SLIM-3.1', 'SLIM-4.1', 'SLIM-4.2', 'SLIM-4.3', 'SLIM-4.4',
-                      'SLIM-5.1', 'SLIM-7.1', 'SLIM-8.1', 'SLIM-9.1', 'SLIM-13.1']:
-            return StandardPractice(
-                best_practice_id=bp_id,
-                uri=uri,
-                title=title,
-                description=description
-            )
-        elif bp_id in ['SLIM-2.1', 'SLIM-2.2']:
-            return SecretsDetection(
-                best_practice_id=bp_id,
-                uri=uri,
-                title=title,
-                description=description
-            )
+        # Determine the appropriate practice class based on the alias
+        practice_class_name = get_practice_class_name(alias)
+        if not practice_class_name:
+            logging.warning(f"No practice class found for alias: {alias}")
+            return None
 
-        logging.warning(f"Unsupported best practice type for ID: {bp_id}")
-        return None
+        # Create and return the appropriate practice instance
+        if practice_class_name == PRACTICE_CLASS_STANDARD:
+            return StandardPractice(
+                best_practice_id=alias,
+                uri=uri,
+                title=title,
+                description=description
+            )
+        elif practice_class_name == PRACTICE_CLASS_SECRETS:
+            return SecretsDetection(
+                best_practice_id=alias,
+                uri=uri,
+                title=title,
+                description=description
+            )
+        elif practice_class_name == PRACTICE_CLASS_DOCGEN:
+            return DocGenPractice()
+        else:
+            logging.warning(f"Unknown practice class: {practice_class_name}")
+            return None
 
     def list_available_practices(self) -> Dict[str, Dict[str, str]]:
         """
@@ -99,14 +114,14 @@ class BestPracticeManager:
             'uri': info.get('asset_uri', '')
         } for bp_id, info in self.registry_dict.items()}
 
-    def is_documentation_practice(self, bp_id: str) -> bool:
+    def is_documentation_practice(self, alias: str) -> bool:
         """
-        Check if a best practice ID is for documentation generation.
+        Check if a best practice alias is for documentation generation.
         
         Args:
-            bp_id: Best practice ID to check
+            alias: Best practice alias to check
             
         Returns:
             True if it's a documentation practice, False otherwise
         """
-        return bp_id in ['doc-gen', 'SLIM-18.1']
+        return is_docgen_practice(alias)

--- a/src/jpl/slim/utils/ai_utils.py
+++ b/src/jpl/slim/utils/ai_utils.py
@@ -69,14 +69,19 @@ def generate_with_ai(best_practice_id, repo_path, template_path, model="openai/g
     if not template_content:
         return None
     
-    # Fetch appropriate reference content based on best practice ID
-    if best_practice_id == 'SLIM-1.1': #governance 
+    # Import the AI context mapping
+    from jpl.slim.best_practices.practice_mapping import get_ai_context_type
+    
+    # Fetch appropriate reference content based on best practice alias
+    context_type = get_ai_context_type(best_practice_id)
+    
+    if context_type == 'governance':
         reference = fetch_readme(repo_path)
         additional_instruction = ""
-    elif best_practice_id == 'SLIM-3.1': #readme
+    elif context_type == 'readme':
         reference = fetch_code_base(repo_path)
         additional_instruction = ""
-    elif best_practice_id == 'SLIM-13.1': #testing
+    elif context_type == 'testing':
         reference1 = fetch_readme(repo_path)
         reference2 = "\n".join(fetch_relative_file_paths(repo_path))
         reference = "EXISTING README:\n" + reference1 + "\n\n" + "EXISTING DIRECTORY LISTING: " + reference2

--- a/src/jpl/slim/utils/io_utils.py
+++ b/src/jpl/slim/utils/io_utils.py
@@ -125,13 +125,13 @@ def fetch_best_practices_from_file(file_path):
 
 def create_slim_registry_dictionary(practices):
     """
-    Create a dictionary of best practices from the SLIM registry.
+    Create a dictionary of best practices from the SLIM registry using aliases as keys.
     
     Args:
         practices: List of best practices
         
     Returns:
-        dict: Dictionary of best practices
+        dict: Dictionary of best practices keyed by alias
     """
     asset_mapping = {}
     
@@ -141,17 +141,21 @@ def create_slim_registry_dictionary(practices):
         
         if 'assets' in practice and practice['assets']:
             for j, asset in enumerate(practice['assets'], start=1):
-                asset_id = f"SLIM-{i}.{j}"
+                # Use alias as the key instead of SLIM-X.X format
+                alias = asset.get('alias')
+                if not alias:
+                    # Skip assets without aliases for now
+                    continue
+                
                 asset_name = asset.get('name', 'N/A')
                 asset_uri = asset.get('uri', '')
-                asset_mapping[asset_id] = {
+                asset_mapping[alias] = {
                     'title': title, 
                     'description': description, 
                     'asset_name': asset_name,
                     'asset_uri': asset_uri
                 }
-        else:
-            asset_mapping[f"SLIM-{i}"] = {'title': title, 'description': description, 'asset_name': 'None'}
+        # Skip practices without assets - they don't have implementations yet
     return asset_mapping
 
 

--- a/tests/jpl/slim/test_best_practices.py
+++ b/tests/jpl/slim/test_best_practices.py
@@ -87,7 +87,7 @@ class TestGovernancePractice:
         mock_repo_obj.working_tree_dir = repo_path # Set the mock's path attribute to match
         mock_git_repo.return_value = mock_repo_obj # Ensure git.Repo(repo_path) returns this mock
         practice = StandardPractice(
-            best_practice_id="SLIM-1.1",
+            best_practice_id="governance-small",
             uri="https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-SMALL-TEAMS.md",
             title="Governance Practice",
             description="Adds governance documentation"
@@ -118,7 +118,7 @@ class TestGovernancePractice:
         mock_repo_obj.working_tree_dir = repo_path
         mock_git_repo.return_value = mock_repo_obj
         practice = StandardPractice(
-            best_practice_id="SLIM-1.1",
+            best_practice_id="governance-small",
             uri="https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-SMALL-TEAMS.md",
             title="Governance Practice",
             description="Adds governance documentation"
@@ -134,7 +134,7 @@ class TestGovernancePractice:
         # Assert
         mock_download.assert_called_once()
         mock_use_ai.assert_called_once_with(
-            "SLIM-1.1",
+            "governance-small",
             repo_path,
             "GOVERNANCE.md",
             "openai/gpt-4o"
@@ -152,7 +152,7 @@ class TestGovernancePractice:
         mock_repo = MagicMock()
         mock_git.Repo.return_value = mock_repo
         practice = StandardPractice(
-            best_practice_id="SLIM-1.1",
+            best_practice_id="governance-small",
             uri="https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-SMALL-TEAMS.md",
             title="Governance Practice",
             description="Adds governance documentation"

--- a/tests/jpl/slim/test_best_practices_manager.py
+++ b/tests/jpl/slim/test_best_practices_manager.py
@@ -24,17 +24,20 @@ def create_slim_registry_dictionary():
                 {
                     "name": "Governance Template (Small Teams)",
                     "type": "text/md",
-                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-SMALL-TEAMS.md"
+                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-SMALL-TEAMS.md",
+                    "alias": "governance-small"
                 },
                 {
                     "name": "Governance Template (Medium Teams)",
                     "type": "text/md",
-                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-MEDIUM-TEAMS.md"
+                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-MEDIUM-TEAMS.md",
+                    "alias": "governance-medium"
                 },
                 {
                     "name": "Governance Template (Large Teams)",
                     "type": "text/md",
-                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-LARGE-TEAMS.md"
+                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-LARGE-TEAMS.md",
+                    "alias": "governance-large"
                 }
             ]
         },
@@ -53,12 +56,14 @@ def create_slim_registry_dictionary():
                 {
                     "name": "GitHub Action Workflow Scan",
                     "type": "text/yaml",
-                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/software-lifecycle/security/secrets-detection/detect-secrets.yaml"
+                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/software-lifecycle/security/secrets-detection/detect-secrets.yaml",
+                    "alias": "secrets-github"
                 },
                 {
                     "name": "Scan Pre-commit Configuration",
                     "type": "text/yaml",
-                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/software-lifecycle/security/secrets-detection/pre-commit-config.yml"
+                    "uri": "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/software-lifecycle/security/secrets-detection/pre-commit-config.yml",
+                    "alias": "secrets-precommit"
                 }
             ]
         }
@@ -69,30 +74,30 @@ class TestBestPracticeManager:
     """Tests for the BestPracticeManager class."""
 
     def test_get_best_practice_returns_governance_practice(self):
-        """Test that get_best_practice returns a GovernancePractice for SLIM-1.1."""
+        """Test that get_best_practice returns a StandardPractice for governance-small."""
         # Arrange
         registry_dict = create_slim_registry_dictionary()
         manager = BestPracticeManager(registry_dict)
         
         # Act
-        practice = manager.get_best_practice("SLIM-1.1")
+        practice = manager.get_best_practice("governance-small")
         
         # Assert
         assert practice is not None
         assert isinstance(practice, StandardPractice)
-        assert practice.best_practice_id == "SLIM-1.1"
+        assert practice.best_practice_id == "governance-small"
         assert practice.title == "GOVERNANCE.md"
         assert practice.uri == "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-SMALL-TEAMS.md"
         assert practice.description == "A governance model template seeking to generalize how most government-sponsored open source projects can expect to operate in the open source arena."
 
     def test_get_best_practice_returns_none_for_invalid_id(self):
-        """Test that get_best_practice returns None for an invalid best practice ID."""
+        """Test that get_best_practice returns None for an invalid best practice alias."""
         # Arrange
         registry_dict = create_slim_registry_dictionary()
         manager = BestPracticeManager(registry_dict)
         
         # Act
-        practice = manager.get_best_practice("INVALID-ID")
+        practice = manager.get_best_practice("invalid-alias")
         
         # Assert
         assert practice is None
@@ -104,31 +109,27 @@ class TestBestPracticeManager:
         manager = BestPracticeManager(registry_dict)
         
         # Act
-        practice = manager.get_best_practice("SLIM-1.2")  # Assuming SLIM-1.2 maps to medium teams
+        practice = manager.get_best_practice("governance-medium")  # Medium teams governance
         
         # Assert
         assert practice is not None
         assert isinstance(practice, StandardPractice)
-        assert practice.best_practice_id == "SLIM-1.2"
+        assert practice.best_practice_id == "governance-medium"
         assert practice.title == "GOVERNANCE.md"
         assert practice.uri == "https://raw.githubusercontent.com/NASA-AMMOS/slim/main/static/assets/governance/governance-model/GOVERNANCE-TEMPLATE-MEDIUM-TEAMS.md"
         assert practice.description == "A governance model template seeking to generalize how most government-sponsored open source projects can expect to operate in the open source arena."
         
-    def test_get_best_practice_returns_standard_practice(self):
-        """Test that get_best_practice returns a StandardPractice for supported IDs."""
+    def test_get_best_practice_returns_secrets_detection_practice(self):
+        """Test that get_best_practice returns a SecretsDetection for secrets aliases."""
         # Arrange
         registry_dict = create_slim_registry_dictionary()
         manager = BestPracticeManager(registry_dict)
         
-        # Act - Add a standard practice ID to the registry for testing
-        manager.registry_dict["SLIM-3.1"] = {
-            "title": "README.md",
-            "description": "A README template", 
-            "asset_uri": "https://example.com/readme.md"
-        }
-        practice = manager.get_best_practice("SLIM-3.1")
+        # Act
+        practice = manager.get_best_practice("secrets-github")
         
         # Assert
         assert practice is not None
-        assert isinstance(practice, StandardPractice)
-        assert practice.best_practice_id == "SLIM-3.1"
+        from jpl.slim.best_practices.secrets_detection import SecretsDetection
+        assert isinstance(practice, SecretsDetection)
+        assert practice.best_practice_id == "secrets-github"

--- a/tests/jpl/slim/test_secrets_detection.py
+++ b/tests/jpl/slim/test_secrets_detection.py
@@ -1,7 +1,7 @@
 """
 Tests for the secrets detection best practices module.
 
-This module contains tests for the SLIM-2.1 and SLIM-2.2 best practices implementation.
+This module contains tests for the secrets-github and secrets-precommit best practices implementation.
 """
 
 import os
@@ -40,15 +40,15 @@ class TestSecretsDetection(unittest.TestCase):
         self.repo.git.commit('-m', 'Initial commit')
 
         # Create instances for testing
-        self.secrets_detection_2_1 = SecretsDetection(
-            best_practice_id='SLIM-2.1',
+        self.secrets_detection_github = SecretsDetection(
+            best_practice_id='secrets-github',
             uri='https://example.com/detect-secrets.yaml',
             title='Secrets Detection',
             description='Implements detect-secrets for scanning repositories'
         )
 
-        self.secrets_detection_2_2 = SecretsDetection(
-            best_practice_id='SLIM-2.2',
+        self.secrets_detection_precommit = SecretsDetection(
+            best_practice_id='secrets-precommit',
             uri='https://example.com/pre-commit-config.yaml',
             title='Pre-commit',
             description='Implements pre-commit hooks'
@@ -72,7 +72,7 @@ class TestSecretsDetection(unittest.TestCase):
         mock_download.return_value = os.path.join(self.test_dir, '.github/workflows/detect-secrets.yaml')
 
         # Execute - always use no_prompt=True for automated testing
-        result = self.secrets_detection_2_1.apply(self.test_dir, no_prompt=True)
+        result = self.secrets_detection_github.apply(self.test_dir, no_prompt=True)
 
         # Assert
         self.assertIsNotNone(result)
@@ -89,7 +89,7 @@ class TestSecretsDetection(unittest.TestCase):
         mock_download.return_value = os.path.join(self.test_dir, '.pre-commit-config.yaml')
 
         # Execute - always use no_prompt=True for automated testing
-        result = self.secrets_detection_2_2.apply(self.test_dir, no_prompt=True)
+        result = self.secrets_detection_precommit.apply(self.test_dir, no_prompt=True)
 
         # Assert
         self.assertIsNotNone(result)
@@ -113,7 +113,7 @@ class TestSecretsDetection(unittest.TestCase):
 
         try:
             # Execute
-            result = self.secrets_detection_2_1.apply(self.test_dir, no_prompt=True)
+            result = self.secrets_detection_github.apply(self.test_dir, no_prompt=True)
 
             # Assert
             self.assertIsNotNone(result)
@@ -137,7 +137,7 @@ class TestSecretsDetection(unittest.TestCase):
 
         try:
             # Execute
-            result = self.secrets_detection_2_2.apply(self.test_dir, no_prompt=True)
+            result = self.secrets_detection_precommit.apply(self.test_dir, no_prompt=True)
 
             # Assert
             self.assertIsNotNone(result)
@@ -161,7 +161,7 @@ class TestSecretsDetection(unittest.TestCase):
 
         try:
             # Execute - should return None because of unverified secrets
-            result = self.secrets_detection_2_1.apply(self.test_dir, no_prompt=True)
+            result = self.secrets_detection_github.apply(self.test_dir, no_prompt=True)
 
             # Assert
             self.assertIsNone(result)  # Application should fail
@@ -176,10 +176,10 @@ class TestSecretsDetection(unittest.TestCase):
         # First apply a practice with no_prompt=True
         with patch('jpl.slim.best_practices.secrets_detection.download_and_place_file') as mock_download:
             mock_download.return_value = os.path.join(self.test_dir, '.github/workflows/detect-secrets.yaml')
-            self.secrets_detection_2_1.apply(self.test_dir, no_prompt=True)
+            self.secrets_detection_github.apply(self.test_dir, no_prompt=True)
 
         # Then deploy
-        result = self.secrets_detection_2_1.deploy(self.test_dir)
+        result = self.secrets_detection_github.deploy(self.test_dir)
 
         # Assert
         self.assertTrue(result)


### PR DESCRIPTION
## Purpose
- Implements a complete migration from SLIM-X.X numeric IDs to descriptive aliases for best practices. The changes replace the old ID-based system with a more intuitive alias-based approach (e.g., readme, governance-small, secrets-github) and improve user experience with clear feedback messages and updated CLI argument names.
## Proposed Changes
- [ADD] Support new slim-registry.json that now has aliases
- [ADD] Centralized practice_mapping.py module following DRY principles for alias-to-implementation mapping
- [ADD] User-friendly stdout success/failure messages for all best practice types (StandardPractice, SecretsDetection, DocGenPractice)
- [ADD] **kwargs support to base BestPractice class and all subclasses for flexible argument handling
- [CHANGE] CLI argument name from --best-practice-ids to --best-practices with helpful examples in help text
- [CHANGE] All internal code to use aliases instead of SLIM-X.X IDs (io_utils.py, BestPracticeManager, best practice classes)
- [CHANGE] AI utilities to use alias-based context mapping instead of hardcoded ID checks
- [CHANGE] README.md examples and documentation to use new --best-practices argument and alias format
- [CHANGE] Documentation in submit-best-practice.md to explain alias requirement for contributors
- [CHANGE] `doc-gen` argument now becomes `docs-website`
- [REMOVE] All backward compatibility support for SLIM-X.X ID format (breaking change)
- [REMOVE] Hardcoded SLIM-X.X conditionals throughout codebase
## Issues
- Resolves issue #17: https://github.com/NASA-AMMOS/slim-cli/issues/17
## Testing
- All 59 existing tests pass successfully
- Tested CLI commands with new --best-practices argument successfully:
  - slim apply --best-practices governance-small --repo-urls https://github.com/riverma/test-repo --no-prompt 
  - slim apply --best-practices secrets-github --repo-urls https://github.com/riverma/test-repo --no-prompt 
  - slim apply --best-practices license-mit --repo-urls https://github.com/riverma/test-repo --no-prompt 