### PR TITLE
Add -r shorthand for --repo-urls argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,28 @@ This section provides detailed commands to interact with the SLIM CLI. Each comm
 To specify a logging level for the app, choose between `DEBUG`, `INFO` (default), `WARNING`, `ERROR`, `CRITICAL`: 
 ```slim --logging DEBUG```
 
+#### Command Shorthands
+
+SLIM CLI provides convenient shorthand options for commonly used arguments:
+
+- `-b` for `--best-practice-ids` - Specify best practice aliases
+- `-r` for `--repo-urls` - Specify repository URLs  
+- `-d` for `--dry-run` - Preview changes without applying them
+- `-l` for `--logging` - Set logging level
+- `-m` for `--commit-message` - Custom commit message (apply-deploy command)
+
+**Examples:**
+```bash
+# Using full argument names
+slim apply --best-practice-ids readme --repo-urls https://github.com/user/repo
+
+# Using shorthands (equivalent)
+slim apply -b readme -r https://github.com/user/repo
+
+# Multiple values with shorthands
+slim apply -b readme -b governance-small -r https://github.com/org/repo1 -r https://github.com/org/repo2
+```
+
 1. **List all available best practices**
    - This command lists all best practices fetched from the SLIM registry.
    ```bash

--- a/src/jpl/slim/app.py
+++ b/src/jpl/slim/app.py
@@ -48,7 +48,13 @@ app = typer.Typer(
   slim apply --best-practice-ids governance-small --repo-urls-file repos.txt\n
   
   [u]Apply docs-website using a cloud AI model:[/u]\n\n
-  slim apply --best-practice-ids docs-website --repo-urls <YOUR_GITHUB_REPO_URL> --output-dir /path/to/new/docs-website-folder-to-create --use-ai anthropic/claude-3-5-sonnet-20241022\n\n
+  slim apply --best-practice-ids docs-website --repo-urls <YOUR_GITHUB_REPO_URL> --output-dir /path/to/new/docs-website-folder-to-create --use-ai anthropic/claude-3-5-sonnet-20241022\n
+  
+  [u]Quick example with shorthands:[/u]\n\n
+  slim apply -b readme -r https://github.com/user/repo\n
+  
+  [u]Multiple values with shorthands:[/u]\n\n
+  slim apply -b readme -b governance-small -r https://github.com/org/repo1 -r https://github.com/org/repo2\n\n
 
 
 [blue]Visit the SLIM website: https://github.com/NASA-AMMOS/slim[/blue]

--- a/src/jpl/slim/commands/apply_command.py
+++ b/src/jpl/slim/commands/apply_command.py
@@ -44,7 +44,7 @@ def apply(
     ),
     repo_urls: Optional[List[str]] = typer.Option(
         None,
-        "--repo-urls",
+        "--repo-urls", "-r",
         help="Repository URLs to apply to. Do not use if --repo-dir specified"
     ),
     repo_urls_file: Optional[Path] = typer.Option(

--- a/src/jpl/slim/commands/apply_deploy_command.py
+++ b/src/jpl/slim/commands/apply_deploy_command.py
@@ -49,7 +49,7 @@ def apply_deploy(
     ),
     repo_urls: Optional[List[str]] = typer.Option(
         None,
-        "--repo-urls",
+        "--repo-urls", "-r",
         help="Repository URLs to apply to. Do not use if --repo-dir specified"
     ),
     repo_urls_file: Optional[Path] = typer.Option(


### PR DESCRIPTION
## Purpose
Add `-r` shorthand option for `--repo-urls` argument to improve CLI usability and reduce typing.

## Proposed Changes
- [ADD] `-r` shorthand to apply and apply-deploy commands
- [ADD] Command Shorthands section in README.md
- [ADD] Shorthand examples in CLI help text

## Issues
- Closes #40

## Testing
- Verified `-r` shorthand in help output for both commands
- Tested with dry-run mode: `slim apply -b readme -r https://github.com/example/repo --dry-run`
- All expected tests passing, backward compatibility maintained